### PR TITLE
fix Matplotlib pyplot allsegs depreciation warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.1.7-alpha (2023-09-19)
+-------------------------
+* Update Cattiaux method to deal with Matplotlib depreciation warning about using 'allsegs'
+or 'collections' in contour plot
+* Add tests for new spatial utils method 'seperate_one_contour_into_line_segments'
+
 
 0.1.6 (2023-09-14)
 -------------------------

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -30,13 +30,12 @@ All methods are implementation from existing research which have been translated
    Metric                                                                          Status              Metric                                                                          Status                                                                                
    =============================================================================== ==============  ==  =============================================================================== ==============
    `Archer & Caldiera 2008 <http://doi.wiley.com/10.1029/2008GL033614>`_           Complete            `Woollings et al. 2010 <https://onlinelibrary.wiley.com/doi/10.1002/qj.625>`_   Complete
-   `Barnes & Polvani 2013 <https://doi.org/10.1175/JCLI-D-12-00536.1>`_            Complete            `Screen & Simmonds 2013 <http://doi.wiley.com/10.1002/grl.50174>`_              In progress*        
-   `Barnes & Polvani 2015 <https://doi.org/10.1175/JCLI-D-14-00589.1>`_            Complete            `Francis & Vavrus 2015 <https://doi.org/10.1088/1748-9326/10/1/014005>`_        Complete            
-   `Grise & Polvani 2016 <https://doi.org/10.1002/2015JD024687>`_                  Complete            `Barnes & Simpson 2017 <https://doi.org/10.1175/JCLI-D-17-0299.1>`_             Complete            
-   `Chenoli et al. 2017 <http://link.springer.com/10.1007/s00382-016-3102-y>`_     In progress         `Molnos et al. 2017  <https://doi.org/10.5194/esd-8-75-2017>`_                  In progress*                   
-   `Bracegirdle et al. 2018 <https://doi.org/10.1175/JCLI-D-17-0320.1>`_           Complete            `Ceppi et al. 2018 <https://doi.org/10.1175/JCLI-D-17-0323.1>`_                 Complete 
-   `Zappa et al. 2018 <https://doi.org/10.1029/2019GL083653>`_                     Complete            `Rikus 2018 <http://dx.doi.org/10.1007/s00382-015-2560-y>`_                     In progress
-   `Kerr et al. 2020 <https://doi.org/10.1029/2020JD032735>`_                      To verify
+   `Barnes & Polvani 2013 <https://doi.org/10.1175/JCLI-D-12-00536.1>`_            Complete            `Screen & Simmonds 2013 <http://doi.wiley.com/10.1002/grl.50174>`_              In progress*    
+   `Barnes & Polvani 2015 <https://doi.org/10.1175/JCLI-D-14-00589.1>`_            Complete            `Grise & Polvani 2016 <https://doi.org/10.1002/2015JD024687>`_                  Complete    
+   `Barnes & Simpson 2017 <https://doi.org/10.1175/JCLI-D-17-0299.1>`_             Complete            `Chenoli et al. 2017 <http://link.springer.com/10.1007/s00382-016-3102-y>`_     In progress
+   `Molnos et al. 2017  <https://doi.org/10.5194/esd-8-75-2017>`_                  In progress*        `Bracegirdle et al. 2018 <https://doi.org/10.1175/JCLI-D-17-0320.1>`_           Complete
+   `Ceppi et al. 2018 <https://doi.org/10.1175/JCLI-D-17-0323.1>`_                 Complete            `Zappa et al. 2018 <https://doi.org/10.1029/2019GL083653>`_                     Complete
+   `Rikus 2018 <http://dx.doi.org/10.1007/s00382-015-2560-y>`_                     In progress         `Kerr et al. 2020 <https://doi.org/10.1029/2020JD032735>`_                      To verify
    =============================================================================== ==============  ==  =============================================================================== ==============
 
 \* == help needed

--- a/jsmetrics/__init__.py
+++ b/jsmetrics/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Tom Keel"""
 __email__ = "thomas.keel.18@ucl.ac.uk"
-__version__ = "0.1.6"
+__version__ = "0.1.7-alpha"
 
 from . import details_for_all_metrics
 from .metrics import jet_core_algorithms, jet_statistics, waviness_metrics

--- a/jsmetrics/core/check_data.py
+++ b/jsmetrics/core/check_data.py
@@ -7,22 +7,6 @@ import functools
 import xarray
 
 
-def check_input_data_is_xarray(func):
-    @functools.wraps(func)
-    def check_data(*args, **kwargs):
-        if "data" in kwargs:
-            data = kwargs["data"]
-        elif args:
-            #  Assumes first argument is data
-            data = args[0]
-        else:
-            return func(*args, **kwargs)
-        check_data_is_xarray(data)
-        return func(*args, **kwargs)
-
-    return check_data
-
-
 def sort_xarray_data_coords(coords, ascending=True):
     """
     Sort the coordinates of the input data (e.g. lat or lon). Sort in ascending order by default.

--- a/jsmetrics/metrics/jet_core_algorithms_components.py
+++ b/jsmetrics/metrics/jet_core_algorithms_components.py
@@ -253,7 +253,7 @@ def run_jet_core_and_region_algorithm_on_one_day(
     )
 
     # Step 6. Remove old jet regions and define two outputs (jet_region, region_above_ws_threshold)
-    row = row.drop("potential_jet_regions")
+    row = row.drop_vars("potential_jet_regions")
     row["jet_region_mask"] = (
         ("plev", "lat", "lon"),
         np.clip(all_jet_regions_mask, 0, 1),
@@ -273,7 +273,7 @@ def run_jet_core_and_region_algorithm_on_one_day(
     )
 
     # Step 8. Remove old and add actual jet core mask
-    row = row.drop("potential_jet_cores")
+    row = row.drop_vars("potential_jet_cores")
     row["jet_core_mask"] = (("plev", "lat", "lon"), jet_core_masks)
     return row
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.6
+current_version = 0.1.7-alpha
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ URL = "https://github.com/Thomasjkeel/jsmetrics"
 AUTHOR = "Thomas Keel"
 AUTHOR_EMAIL = "thomas.keel.18@ucl.ac.uk"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.1.6"
+VERSION = "0.1.7-alpha"
 LICENSE = "MIT License"
 
 KEYWORDS = "jet-stream climate metrics algorithms xarray"

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -94,6 +94,48 @@ class TestAddNumDaysto360Datetime(unittest.TestCase):
         self.assertRaises(ValueError, lambda: tested_func(test_date, -1))
 
 
+class TestAddNumDaystoNoLeapDatetime(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                cftime.DatetimeNoLeap(day=1, month=1, year=2020, hour=1),
+                365,
+                cftime.DatetimeNoLeap(day=1, month=1, year=2021, hour=12),
+            ),
+            (
+                cftime.DatetimeNoLeap(day=1, month=1, year=2019, hour=1),
+                365,
+                cftime.DatetimeNoLeap(day=1, month=1, year=2020, hour=12),
+            ),
+            (
+                cftime.DatetimeNoLeap(day=28, month=2, year=2020, hour=1),
+                1,
+                cftime.DatetimeNoLeap(day=1, month=3, year=2020, hour=12),
+            ),
+        ]
+    )
+    def test_add_num_of_days_to_NoLeapDatetime(
+        self, test_date, days_to_add, expected_new_date
+    ):
+        added_test_date = data_utils.add_num_of_days_to_NoLeapDatetime(
+            test_date, num_of_days_to_add=days_to_add
+        )
+        self.assertEqual(added_test_date, expected_new_date)
+
+    def test_errors_raised(self):
+        tested_func = data_utils.add_num_of_days_to_NoLeapDatetime
+        test_date = cftime.DatetimeNoLeap(day=1, month=1, year=2000, hour=1)
+        self.assertRaises(
+            AssertionError, lambda: tested_func(np.datetime64("1970-01-11"), 1)
+        )
+        self.assertRaises(
+            AssertionError,
+            lambda: tested_func(cftime.DatetimeAllLeap(day=1, month=1, year=2000), 1),
+        )
+        self.assertRaises(ValueError, lambda: tested_func(test_date, 0))
+        self.assertRaises(ValueError, lambda: tested_func(test_date, -1))
+
+
 class TestLocalMinimaMaxima(unittest.TestCase):
     def setUp(self):
         self.data = set_up_test_uv_data()

--- a/tests/unit/test_jet_algorithms.py
+++ b/tests/unit/test_jet_algorithms.py
@@ -149,7 +149,9 @@ class TestKuang2014(unittest.TestCase):
         self.assertEqual(result["jet_ocurrence1_jet_centre2"].max(), 2)
         lon_data = self.data.sel(plev=slice(50000, 25000)).isel(time=slice(0, 2))
         self.assertRaises(ValueError, lambda: tested_func(lon_data))
-        plev_data = self.data.sel(plev=slice(25000, 25000)).isel(time=slice(0, 2))
+        plev_data = self.data.sel(plev=slice(25000, 25000)).isel(
+            time=slice(0, 1), lat=slice(0, 10), lon=slice(0, 10)
+        )
         tested_func(plev_data)
 
 

--- a/tests/unit/test_jet_algorithms.py
+++ b/tests/unit/test_jet_algorithms.py
@@ -87,6 +87,10 @@ class TestSchiemann2009(unittest.TestCase):
         print(result)
         self.assertTrue(result)
         self.assertEqual(int(result["jet_occurence"].isel(plev=0, lat=50, lon=10)), 1)
+        self.assertRaises(
+            KeyError,
+            lambda: tested_func(self.data.isel(time=0).drop("time")),
+        )
 
 
 class TestManney2011(unittest.TestCase):
@@ -94,23 +98,28 @@ class TestManney2011(unittest.TestCase):
         self.data = set_up_test_uv_data()
 
     def test_metric(self):
-        test_func = jet_core_algorithms.manney_et_al_2011
-        # NOTE: this metric is a generator
+        tested_func = jet_core_algorithms.manney_et_al_2011
         subset_data = self.data.sel(plev=slice(50000, 10000)).isel(
             time=slice(0, 1), lon=slice(0, 100)
         )
-        res = test_func(subset_data, jet_core_plev_limit=(10000, 40000))
+        res = tested_func(subset_data, jet_core_plev_limit=(10000, 40000))
         self.assertEqual(int(res["jet_core_mask"].astype(int).max()), 1)
         self.assertEqual(int(res["jet_region_mask"].astype(int).max()), 1)
         self.assertEqual(
             int(res["jet_core_mask"].isel(lon=0).where(lambda x: x).count()), 1
         )
 
-        res = test_func(
+        res = tested_func(
             subset_data, jet_core_plev_limit=(10000, 40000), jet_core_ws_threshold=10
         )
         self.assertEqual(
             int(res["jet_core_mask"].isel(lon=0).where(lambda x: x).count()), 4
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: tested_func(
+                self.data.isel(time=0).drop("time"), jet_core_plev_limit=(10000, 40000)
+            ),
         )
 
 
@@ -126,15 +135,19 @@ class TestPenaOrtiz2013(unittest.TestCase):
         self.assertEqual(res["subtropical_jet"].max(), 1)
 
     def test_get_empty_local_wind_maxima(self):
-        test_func = jet_core_algorithms_components.get_empty_local_wind_maxima_data
-        empty_local_wind_data = test_func(self.data)
+        tested_func = jet_core_algorithms_components.get_empty_local_wind_maxima_data
+        empty_local_wind_data = tested_func(self.data)
         self.assertEqual(empty_local_wind_data.max(), 0)
         self.assertTrue("local_wind_maxima" in empty_local_wind_data)
 
     def test_get_local_wind_maxima_by_timeunit(self):
-        test_func = jet_core_algorithms_components.get_local_wind_maxima_by_timeunit
+        tested_func = jet_core_algorithms_components.get_local_wind_maxima_by_timeunit
         self.assertRaises(
-            ValueError, lambda: test_func(self.data.isel(time=0), ws_threshold=30)
+            ValueError, lambda: tested_func(self.data.isel(time=0), ws_threshold=30)
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: tested_func(self.data.isel(time=0).drop("time"), ws_threshold=30),
         )
 
 
@@ -160,13 +173,17 @@ class TestJetCoreIdentificationAlgorithm(unittest.TestCase):
         self.data = set_up_test_uv_data()
 
     def test_metric(self):
-        test_func = jet_core_algorithms.jet_core_identification_algorithm
+        tested_func = jet_core_algorithms.jet_core_identification_algorithm
         # NOTE: this metric is a generator
         subset_data = self.data.sel(plev=25000).isel(
             time=slice(0, 1), lat=slice(20, 30)
         )
-        res = test_func(subset_data)
+        res = tested_func(subset_data)
         self.assertEqual(res["jet_core_id"].max(), 2)
+        self.assertRaises(
+            KeyError,
+            lambda: tested_func(self.data.isel(time=0).drop("time")),
+        )
 
 
 class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
@@ -193,18 +210,18 @@ class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
 
     def test_inner_funcs(self):
         tested_alg = jet_core_algorithms_components.JetStreamCoreIdentificationAlgorithm
-        test_data = self.data.isel(time=0, lon=0, lat=slice(20, 30))
+        test_data = self.data.isel(time=0, lon=0, lat=slice(20, 50))
         result = tested_alg(test_data)
         result.run()
         print(result._initial_core_ids.mean())
-        self.assertEqual(round(result._initial_core_ids.mean(), 3), 7.75)
-        self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 46)
+        self.assertEqual(round(result._initial_core_ids.mean(), 3), 11.25)
+        self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 16)
         self.assertEqual(
             len(np.where(result._labelled_data["ws"] == "Potential Boundary")[1]),
-            81,
+            39,
         )
-        self.assertEqual(result.num_of_cores, 3)
-        self.assertListEqual(result.final_jet_cores[0]["index_of_area"][0], [16, 4])
+        self.assertEqual(result.num_of_cores, 1)
+        self.assertListEqual(result.final_jet_cores[0]["index_of_area"][0], [8, 7])
 
     def test_classmethod(self):
         tested_alg = (
@@ -213,7 +230,7 @@ class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
         test_data = self.data.isel(time=0, lon=0, lat=slice(20, 30))
         result = tested_alg(test_data)
         self.assertEqual(round(result._initial_core_ids.mean(), 3), 7.75)
-        self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 46)
+        self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 2)
 
 
 class TestJetStreamOccurenceAndCentreAlgorithm(unittest.TestCase):
@@ -232,7 +249,7 @@ class TestJetStreamOccurenceAndCentreAlgorithm(unittest.TestCase):
         result = self.tested_alg(test_data)
         result.run()
         self.assertEqual(round(float(result._jet_occurence["ws"].max()), 3), 69.214)
-        self.assertListEqual(result._jet_centres[0].tolist(), [0.0, 247.5])
+        self.assertListEqual(result._jet_centres[0].tolist(), [30.0, 16.875])
 
     def test_cls_method(self):
         test_data = self.data.isel(plev=4, lat=slice(20, 30), lon=slice(0, 10), time=0)

--- a/tests/unit/test_jet_algorithms.py
+++ b/tests/unit/test_jet_algorithms.py
@@ -162,8 +162,10 @@ class TestJetCoreIdentificationAlgorithm(unittest.TestCase):
     def test_metric(self):
         test_func = jet_core_algorithms.jet_core_identification_algorithm
         # NOTE: this metric is a generator
-        subset_data = self.data.sel(plev=slice(25000, 20000)).isel(time=slice(0, 1))
-        res = test_func(subset_data.sel(plev=25000))
+        subset_data = self.data.sel(plev=25000).isel(
+            time=slice(0, 1), lat=slice(20, 30)
+        )
+        res = test_func(subset_data)
         self.assertEqual(res["jet_core_id"].max(), 2)
 
 

--- a/tests/unit/test_jet_algorithms.py
+++ b/tests/unit/test_jet_algorithms.py
@@ -185,7 +185,7 @@ class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
     def test_ws_thresholds(self):
         tested_alg = jet_core_algorithms_components.JetStreamCoreIdentificationAlgorithm
         self.assertRaises(ValueError, lambda: tested_alg(self.data))
-        test_data = self.data.isel(time=0, lon=0)
+        test_data = self.data.isel(time=0, lon=0, lat=slice(20, 30))
         self.assertRaises(ValueError, lambda: tested_alg(test_data, -10, 10))
         self.assertRaises(ValueError, lambda: tested_alg(test_data, 10, -10))
         self.assertRaises(ValueError, lambda: tested_alg(test_data, 10, 30))
@@ -193,11 +193,11 @@ class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
 
     def test_inner_funcs(self):
         tested_alg = jet_core_algorithms_components.JetStreamCoreIdentificationAlgorithm
-        test_data = self.data.isel(time=0, lon=0)
+        test_data = self.data.isel(time=0, lon=0, lat=slice(20, 30))
         result = tested_alg(test_data)
         result.run()
         print(result._initial_core_ids.mean())
-        self.assertEqual(result._initial_core_ids.mean(), 30.07608695652174)
+        self.assertEqual(round(result._initial_core_ids.mean(), 3), 7.75)
         self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 46)
         self.assertEqual(
             len(np.where(result._labelled_data["ws"] == "Potential Boundary")[1]),
@@ -210,9 +210,9 @@ class TestJetStreamCoreIdentificationAlgorithm(unittest.TestCase):
         tested_alg = (
             jet_core_algorithms_components.JetStreamCoreIdentificationAlgorithm.run_algorithm
         )
-        test_data = self.data.isel(time=0, lon=0)
+        test_data = self.data.isel(time=0, lon=0, lat=slice(20, 30))
         result = tested_alg(test_data)
-        self.assertEqual(result._initial_core_ids.mean(), 30.07608695652174)
+        self.assertEqual(round(result._initial_core_ids.mean(), 3), 7.75)
         self.assertEqual(len(np.where(result._labelled_data["ws"] == "Core")[1]), 46)
 
 
@@ -224,20 +224,20 @@ class TestJetStreamOccurenceAndCentreAlgorithm(unittest.TestCase):
         )
 
     def test_ws_thresholds(self):
-        test_data = self.data.isel(plev=0, time=0)
+        test_data = self.data.isel(plev=0, time=0, lat=slice(20, 30), lon=slice(0, 10))
         self.assertRaises(ValueError, lambda: self.tested_alg(test_data, -10))
 
     def test_inner_functions(self):
-        test_data = self.data.isel(plev=4, time=0)
+        test_data = self.data.isel(plev=4, time=0, lat=slice(20, 30), lon=slice(0, 10))
         result = self.tested_alg(test_data)
         result.run()
-        self.assertEqual(float(result._jet_occurence["ws"].max()), 85.84358978271484)
+        self.assertEqual(round(float(result._jet_occurence["ws"].max()), 3), 69.214)
         self.assertListEqual(result._jet_centres[0].tolist(), [0.0, 247.5])
 
     def test_cls_method(self):
-        test_data = self.data.isel(plev=4, time=0)
+        test_data = self.data.isel(plev=4, lat=slice(20, 30), lon=slice(0, 10), time=0)
         result = self.tested_alg.run_algorithm(test_data)
-        self.assertEqual(float(result._jet_occurence["ws"].max()), 85.84358978271484)
+        self.assertEqual(round(float(result._jet_occurence["ws"].max()), 3), 69.214)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_jet_algorithms.py
+++ b/tests/unit/test_jet_algorithms.py
@@ -133,6 +133,10 @@ class TestPenaOrtiz2013(unittest.TestCase):
         res = tested_func(subset_data)
         self.assertTrue("polar_front_jet" in res)
         self.assertEqual(res["subtropical_jet"].max(), 1)
+        self.assertRaises(
+            KeyError,
+            lambda: tested_func(self.data.isel(time=0).drop("time")),
+        )
 
     def test_get_empty_local_wind_maxima(self):
         tested_func = jet_core_algorithms_components.get_empty_local_wind_maxima_data
@@ -144,10 +148,6 @@ class TestPenaOrtiz2013(unittest.TestCase):
         tested_func = jet_core_algorithms_components.get_local_wind_maxima_by_timeunit
         self.assertRaises(
             ValueError, lambda: tested_func(self.data.isel(time=0), ws_threshold=30)
-        )
-        self.assertRaises(
-            KeyError,
-            lambda: tested_func(self.data.isel(time=0).drop("time"), ws_threshold=30),
         )
 
 
@@ -182,7 +182,7 @@ class TestJetCoreIdentificationAlgorithm(unittest.TestCase):
         self.assertEqual(res["jet_core_id"].max(), 2)
         self.assertRaises(
             KeyError,
-            lambda: tested_func(self.data.isel(time=0).drop("time")),
+            lambda: tested_func(self.data.isel(time=0).drop_vars("time")),
         )
 
 

--- a/tests/unit/test_jet_statistics.py
+++ b/tests/unit/test_jet_statistics.py
@@ -145,6 +145,12 @@ class TestArcherCaldeira2008(unittest.TestCase):
         test_data = self.data.isel(plev=1)
         # should fail because needs two plevs
         self.assertRaises(ValueError, lambda: tested_func(test_data))
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.archer_caldeira_2008(
+                self.data.isel(time=0).drop("time")
+            ),
+        )
 
 
 class TestWoollings2010(unittest.TestCase):
@@ -300,6 +306,12 @@ class TestBarnesSimpson2017(unittest.TestCase):
         result = test_func(self.data)
         self.assertEqual(round(float(result["jet_lat"].mean()), 5), 36.25)
         self.assertEqual(round(float(result["jet_speed"].max()), 5), 22.05004)
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.barnes_simpson_2017(
+                self.data["ua"].isel(time=0).drop("time")
+            ),
+        )
 
 
 class TestBracegirdle2018(unittest.TestCase):
@@ -316,6 +328,12 @@ class TestBracegirdle2018(unittest.TestCase):
         self.assertEqual(float(result["annual_JPOS"].max()), 37.725)
         self.assertEqual(round(float(result["seasonal_JSTR"].max()), 3), 8.589)
         self.assertEqual(round(float(result["annual_JSTR"].max()), 3), 8.589)
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.bracegirdle_et_al_2018(
+                self.data["ua"].isel(time=0).drop("time")
+            ),
+        )
 
 
 class TestCeppi2018(unittest.TestCase):
@@ -344,6 +362,12 @@ class TestCeppi2018(unittest.TestCase):
             ValueError,
             lambda: tested_func(
                 self.data.sel(lon=slice(0, 0), lat=slice(0, 0)), lon_resolution=1.875
+            ),
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.ceppi_et_al_2018(
+                self.data["ua"].isel(time=0).drop("time")
             ),
         )
 
@@ -376,6 +400,12 @@ class TestZappa2018(unittest.TestCase):
                 self.data.sel(lon=slice(0, 0), lat=slice(0, 0)), lon_resolution=1.875
             ),
         )
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.zappa_et_al_2018(
+                self.data["ua"].isel(time=0).drop("time")
+            ),
+        )
 
 
 class TestKerr2020(unittest.TestCase):
@@ -390,6 +420,12 @@ class TestKerr2020(unittest.TestCase):
         self.assertEqual(float(result["jet_lat"].max()), 72.5)
         self.assertEqual(float(result["smoothed_jet_lat"].max()), 65.0)
         self.assertEqual(result["smoothed_jet_lat"].isel(time=0).dropna("lon").size, 61)
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.kerr_et_al_2020(
+                self.data["ua"].isel(time=0).drop("time")
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_jet_statistics.py
+++ b/tests/unit/test_jet_statistics.py
@@ -148,7 +148,7 @@ class TestArcherCaldeira2008(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.archer_caldeira_2008(
-                self.data.isel(time=0).drop("time")
+                self.data.isel(time=0).drop_vars("time")
             ),
         )
 
@@ -292,7 +292,7 @@ class TestGrisePolvani2016(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.grise_polvani_2016(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 
@@ -309,7 +309,7 @@ class TestBarnesSimpson2017(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.barnes_simpson_2017(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 
@@ -331,7 +331,7 @@ class TestBracegirdle2018(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.bracegirdle_et_al_2018(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 
@@ -367,7 +367,7 @@ class TestCeppi2018(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.ceppi_et_al_2018(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 
@@ -403,7 +403,7 @@ class TestZappa2018(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.zappa_et_al_2018(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 
@@ -423,7 +423,7 @@ class TestKerr2020(unittest.TestCase):
         self.assertRaises(
             KeyError,
             lambda: jet_statistics.kerr_et_al_2020(
-                self.data["ua"].isel(time=0).drop("time")
+                self.data["ua"].isel(time=0).drop_vars("time")
             ),
         )
 

--- a/tests/unit/test_jet_statistics.py
+++ b/tests/unit/test_jet_statistics.py
@@ -283,6 +283,12 @@ class TestGrisePolvani2016(unittest.TestCase):
         self.assertEqual(float(result["jet_lat"].min()), 35.38)
         self.assertEqual(float(result["jet_lat"].max()), 36.41)
         self.assertEqual(round(float(result["jet_speed"].max()), 5), 22.92644)
+        self.assertRaises(
+            KeyError,
+            lambda: jet_statistics.grise_polvani_2016(
+                self.data["ua"].isel(time=0).drop("time")
+            ),
+        )
 
 
 class TestBarnesSimpson2017(unittest.TestCase):

--- a/tests/unit/test_waviness_metrics.py
+++ b/tests/unit/test_waviness_metrics.py
@@ -38,4 +38,4 @@ class TestCattiaux2016(unittest.TestCase):
         subset_data = self.data.isel(plev=0)
         res = tested_func(subset_data)
         tested_func(subset_data["zg"])
-        self.assertEqual(round(float(res["sinuosity"].max()), 3), 2.749)
+        self.assertEqual(round(float(res["sinuosity"].max()), 3), 2.747)


### PR DESCRIPTION
The method from Cattiaux et al. 2016 relies on plt.contour plot which was throwing a depreciation error due to using 'allsegs' param. This has been fixed by converting the 'all_paths()' parameter of one contour into multilinestring by default using a new method 'seperate_one_contour_into_line_segments'.  